### PR TITLE
Pysolfc fixes

### DIFF
--- a/pkgs/games/pysolfc/default.nix
+++ b/pkgs/games/pysolfc/default.nix
@@ -26,6 +26,7 @@ buildPythonApplication rec {
   nativeBuildInputs = [ desktop-file-utils ];
   postPatch = ''
     desktop-file-edit --set-key Exec --set-value $out/bin/pysol.py data/pysol.desktop
+    sed -i s:/usr/share/PySolFC:$out/share/PySolFC: pysollib/settings.py
   '';
   
   postInstall = ''


### PR DESCRIPTION
* desktop file now points to the right executable
* adds tkinter back as a dependency
* fixes path to data directory (this was done by an overcomplicated patch before; I think this sed command is a more robust solution)